### PR TITLE
WS2-321 change login username fallback

### DIFF
--- a/src/Plugin/Block/AsuBrandHeaderBlock.php
+++ b/src/Plugin/Block/AsuBrandHeaderBlock.php
@@ -66,13 +66,14 @@ class AsuBrandHeaderBlock extends BlockBase {
     // rely on Drupal instead, via passing in props.
     if ($config['asu_brand_header_block_sync_session']) {
       $current_uid = \Drupal::currentUser()->id();
-      $current_user = \Drupal\user\Entity\User::load($current_uid);
       if ($current_uid > 0) {
         $props['loggedIn'] = TRUE;
         // If we have the SSONAME cookie, use that name. Fallback to
-        // ASURITE/username. See also JS solve we have as a backup for
+        // "You are logged in" since using the username results in cache issues
+        // given the per-role cache. Caching per user causes the header to
+        // break for some reason. See also JS solve we have as a backup for
         // when Pantheon strips cookies, in asu_brand.header.js.
-        $props['userName'] = isset($_COOKIE['SSONAME']) ? Html::escape($_COOKIE['SSONAME']) : $current_user->get('name')->value;
+        $props['userName'] = isset($_COOKIE['SSONAME']) ? Html::escape($_COOKIE['SSONAME']) : t('You are logged in');
       } else { // Force header to match Drupal login state even if there's a SSO session.
         $props['loggedIn'] = FALSE;
         $props['userName'] = '';


### PR DESCRIPTION
@duarte-daniela When you are able, would you please review and merge if this looks good? 

If a user is not logged in with CAS, the header doesn't have their name and was using the currently logged in username as a fallback for their name. The problem with that was that the ASU Brand header block is cached by role, so when the fallback username was used, it was sometimes showing the wrong name for some users. I've changed the fallback to read "You are logged in" and not try to use a name. Itzel was good with that.

Trying to change the header block to cache by user just wasn't working. Was breaking the header for some reason, and not really worth troubleshooting with this simple solve, which will be bette for cache size and performance anyway.