### PR TITLE
WS2-945: add dataLayer init. split GTM for delivery to head and body …

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,20 @@ body.asu-brand-header-present {
      js/asu_brand.header.js */
 }
 ```
+## Extending the Google Analytics dataLayer
+The ASU Brand module initializes a Google Analytics dataLayer for use by
+frontend Unity components. The dataLayer has been implmented so that
+modules may take advantage of it as well using the
+hook_asu_brand_gtm_datalayer_alter() hook. Please note, use of this hook to
+add page-based dataLayer pushes has not been tested, so it is encumbent on
+the developer implementing to ensure it behaves as desired and doesn't
+interfere with other dataLayer usage on existing pages. If you test this,
+we would appreciate hearing about your experience.
+
+```
+function hook_asu_brand_gtm_datalayer_alter(array &$datalayer) {
+  // Set a "site" variable return.
+  $datalayer['site'] = 'My Site';
+}
+*/
+```

--- a/asu_brand.module
+++ b/asu_brand.module
@@ -4,7 +4,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Component\Uuid\Uuid;
-
+use Drupal\Component\Serialization\Json;
 
 /**
  * @file
@@ -19,7 +19,7 @@ use Drupal\Component\Uuid\Uuid;
 function asu_brand_entity_base_field_info(\Drupal\Core\Entity\EntityTypeInterface $entity_type) {
   if ($entity_type->id() === 'menu_link_content') {
 
-    // TODO Future impreoment: Use form alter (below) to make these fields
+    // TODO Future improvement: Use form alter (below) to make these fields
     // present better and add form states api logic for the button color
     // control and maybe to hide the "Show as expanded" field if this field is
     // a header block menu, since we don't consult that setting.
@@ -166,6 +166,8 @@ function asu_brand_form_menu_link_content_form_alter(array &$form, FormStateInte
   ];
 }
 
+/** Google Analytics, Google Tag Manager and dataLayer initialization below. */
+
 /**
  * Implements hook_page_top().
  *
@@ -188,7 +190,7 @@ function asu_brand_page_top(array &$page_top) {
   if ($gtm_enabled) {
 
     $asu_universal_gtm = $asu_gtm;
-    $gtm_snippet = _asu_brand_gtm_snippet($asu_universal_gtm);
+    $gtm_body_snippet = _asu_brand_gtm_body_snippet($asu_universal_gtm);
 
     // We insert the JS inline with the HTML due to load time needs. Turns
     // out that's not super easy in D9. But the following works. For discussion
@@ -204,9 +206,9 @@ function asu_brand_page_top(array &$page_top) {
     // Add GTM snippet to page_top render array as #children which is assumed
     // to be a string of already rendered markup.
     $page_top['asu_brand_universal_gtm'] = [
-      '#children' => $gtm_snippet,
+      '#children' => $gtm_body_snippet,
       // Alternatively, but strips style attribute and possibly more:
-      //'#markup' => $gtm_snippet,
+      //'#markup' => $gtm_body_snippet,
       //'#allowed_tags' => ['script', 'noscript', 'iframe'],
     ];
   }
@@ -214,7 +216,7 @@ function asu_brand_page_top(array &$page_top) {
   // Extra GTM
   if ($extra_gtm) {
 
-    $extra_gtm_snippet = _asu_brand_gtm_snippet($extra_gtm);
+    $extra_gtm_snippet = _asu_brand_gtm_body_snippet($extra_gtm);
 
     // Add to page_top render array as #markup with allowed tags defined to
     // avoid sanitization of snippet on render.
@@ -229,9 +231,31 @@ function asu_brand_page_top(array &$page_top) {
 }
 
 /**
- * Internal helper function to return a GTM snippet with GTM ID embedded.
+ * Internal helper function to return a GTM header snippet with GTM ID embedded.
  */
-function _asu_brand_gtm_snippet($gtm_id) {
+function _asu_brand_gtm_head_snippet($gtm_id) {
+
+  // Santize GTM ID. Secure code high-five!
+  $gtm_id = HTML::escape($gtm_id);
+
+  // <script> tags will be added for us.
+  $gtm_head_snippet = <<<EOT
+
+    // Google Tag Manager - $gtm_id
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','$gtm_id');
+
+EOT;
+  return $gtm_head_snippet;
+}
+
+/**
+ * Internal helper function to return a GTM body snippet with GTM ID embedded.
+ */
+function _asu_brand_gtm_body_snippet($gtm_id) {
 
   // Santize GTM ID. Secure code high-five!
   $gtm_id = HTML::escape($gtm_id);
@@ -242,19 +266,159 @@ function _asu_brand_gtm_snippet($gtm_id) {
   // #children in the render array. It's important that any code here is
   // owned 100% by this module OR sanitized, as we've done with the $gtm_id.
 
-  $gtm_snippet = <<<EOT
+  $gtm_body_snippet = <<<EOT
 
-    <!-- Google Tag Manager - $gtm_id -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','$gtm_id');</script>
+    <!-- Google Tag Manager (noscript) - $gtm_id -->
     <noscript><iframe src="//www.googletagmanager.com/ns.html?id=$gtm_id"
     height="0" width="0" style="display:none;visibility:hidden"></iframe>
     </noscript>
-    <!-- End Google Tag Manager - $gtm_id -->
+    <!-- End Google Tag Manager (noscript) - $gtm_id -->
 
 EOT;
-  return $gtm_snippet;
+  return $gtm_body_snippet;
 }
+
+/**
+ * Implements hook_page_attachments().
+ *
+ * Initialize GTM dataLayer and add GTM head snippet.
+ *
+ * Much of the concept for how we implement the dataLayer comes from the
+ * Drupal dataLayer contrib module. An entrypoint for comparing that approach
+ * to ours would be to start at
+ * https://git.drupalcode.org/project/datalayer/-/blob/8.x-1.0-beta2/datalayer.module#L65
+ */
+function asu_brand_page_attachments(array &$attachments) {
+  $config = \Drupal::config('asu_brand.settings');
+  // ASU Universal GTM ID is stored in settings, but not updatable through UI.
+  $asu_gtm = $config->get('asu_brand.asu_brand_universal_gtm_id');
+  $gtm_enabled = $config->get('asu_brand.asu_brand_gtm_enabled');
+  $extra_gtm = $config->get('asu_brand.asu_brand_extra_gtm_id');
+
+  if ($gtm_enabled || $extra_gtm) {
+
+    if (empty($attachments['#attached'])) {
+      $attachments['#attached'] = [];
+    }
+    if (empty($attachments['#attached']['html_head'])) {
+      $attachments['#attached']['html_head'] = [];
+    }
+
+    // Check if site is sending in dataLayer details to push. Otherwise, just
+    // initialize dataLayer for frontend component use.
+    $datalayer_attachment = asu_brand_gtm_datalayer_get_data_from_page();
+    if (empty($datalayer_attachment)) {
+      $datalayer_init = 'window.dataLayer = window.dataLayer || [];';
+    } else {
+      $datalayer_init = 'window.dataLayer = window.dataLayer || []; window.dataLayer.push(' . Json::encode($datalayer_attachment) . ');';
+    }
+
+    $attachments['#attached']['html_head'][] = [
+      [
+        '#type' => 'html_tag',
+        '#tag' => 'script',
+        '#value' => $datalayer_init,
+      ],
+      'asu-brand-datalayers-js',
+    ];
+  }
+
+  if ($gtm_enabled) {
+    $asu_universal_gtm = $asu_gtm;
+    $universal_gtm_header_snippet = _asu_brand_gtm_head_snippet($asu_universal_gtm);
+    $attachments['#attached']['html_head'][] = [
+      [
+        '#type' => 'html_tag',
+        '#tag' => 'script',
+        '#value' => $universal_gtm_header_snippet,
+      ],
+      'asu-brand-universal-gtm-head-snippet',
+    ];
+  }
+
+  if ($extra_gtm) {
+    $extra_gtm_header_snippet = _asu_brand_gtm_head_snippet($extra_gtm);
+    $attachments['#attached']['html_head'][] = [
+      [
+        '#type' => 'html_tag',
+        '#tag' => 'script',
+        '#value' => $extra_gtm_header_snippet,
+      ],
+      'asu-brand-extra-gtm-head-snippet',
+    ];
+  }
+}
+
+/**
+ * Allow adding to the data layer easy on the fly, similar to drupal_add_js().
+ *
+ * Passing empty params will return current dataLayer output.
+ *
+ * @param array $data
+ *   An array of dataLayer data keyed by variable name (optional).
+ * @param bool $overwrite
+ *   If data should overwrite existing dataLayer vars of same name (optional).
+ *
+ * @return array
+ *   All data layer data added thus far.
+ */
+function asu_brand_datalayer_add(array $data = [], $overwrite = FALSE) {
+  $output_data = &drupal_static(__FUNCTION__, _asu_brand_datalayer_defaults());
+
+  // If we've been given data, add it to the output.
+  if (!empty($data)) {
+    if ($overwrite) {
+      $output_data = array_merge($output_data, $data);
+    } else {
+      $output_data += $data;
+    }
+  }
+
+  return $output_data;
+}
+
+/**
+ * Add data for output. Opportunity to gather data from current execution.
+ *
+ * Also invokes hook_asu_brand_gtm_datalayer_alter()
+ */
+function asu_brand_gtm_datalayer_get_data_from_page() {
+
+  $datalayer = _asu_brand_datalayer_defaults();
+
+  // Example: Add active user uid using asu_brand_datalayer_add().
+  // $user = \Drupal::currentUser();
+  // $datalayer = asu_brand_datalayer_add(['userUid' => $user->id()]);
+
+  // Allow modules to alter data with hook_asu_brand_gtm_datalayer_alter().
+  \Drupal::moduleHandler()->alter('asu_brand_gtm_datalayer', $datalayer);
+
+  return $datalayer;
+}
+
+/**
+ * Defines Drupal-wide data layer defaults.
+ */
+function _asu_brand_datalayer_defaults() {
+
+  // We could set default data to always include from CMS later, if we want.
+
+  // We return nothing, by default. Just initializing for frontend components.
+  return [];
+}
+
+/**
+ * Example: Modules can alter the dataLayer data before it is output.
+ *
+ * Implements hook_asu_brand_gtm_datalayer_alter().
+ *
+ * @param array $datalayer
+ *   GTM data layer data for the current page.
+ */
+/*
+function asu_brand_asu_brand_gtm_datalayer_alter(array &$datalayer) {
+  // EXAMPLE:
+  // Set a "site" variable return.
+  $datalayer['site'] = 'My Site';
+}
+*/


### PR DESCRIPTION
…per docs

Per https://asudev.jira.com/browse/WS2-945 I've added a dataLayer init for the Google Analytics dataLayer.

I also implemented an alter hook so that if at a future date we wanted to add dataLayer pushes *from the CMS* instead of just the Unity Components, we could do that. This functionality is untested, but in place for if and when we might want it. I added a note to this effect in the README.md.

While at it, I took the time to improve delivery of the GTM snippets so that the best practices of adding one snippet to the head tag and the other to the body is now honored. 

Screenshot of these updates:

![2021-09-22_18-56-56](https://user-images.githubusercontent.com/212131/134444375-55c672ad-fce0-4434-b910-5aa352d219d1.png)
 