### PR TITLE
remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,5 @@
             "email": "mlsamuel@asu.edu"
         }
     ],
-    "require": {},
-    "version": "1.2.5"
+    "require": {}
 }


### PR DESCRIPTION
I created a tagged release, but I either needed to update the version in composer.json or remove it. Packagist recommends removing it, so that's what I did.