### PR TITLE
WS2-1314 fix local search fallback

### DIFF
--- a/src/Form/AsuBrandSettingsForm.php
+++ b/src/Form/AsuBrandSettingsForm.php
@@ -108,7 +108,7 @@ class AsuBrandSettingsForm extends ConfigFormBase {
       '#title' => $this->t('Local Search URL'),
       '#default_value' => $config->get('asu_brand.asu_brand_local_search_url'),
       '#description' => $this->t('If empty, your current site\'s base URL will be used. Optionally, you can override
-         with the URL of your choice to be used for scoping local search. Use the format: https://yourdomain.asu.edu.'),
+         with the URL of your choice to be used for scoping local search. Use the format: yourdomain.asu.edu'),
     ];
 
     return parent::buildForm($form, $form_state);

--- a/src/Plugin/Block/AsuBrandHeaderBlock.php
+++ b/src/Plugin/Block/AsuBrandHeaderBlock.php
@@ -112,7 +112,8 @@ class AsuBrandHeaderBlock extends BlockBase {
     // Search settings.
     $search_config = \Drupal::config('asu_brand.settings');
     $props['searchUrl'] = $search_config->get('asu_brand.asu_brand_search_url');
-    $props['site'] = $search_config->get('asu_brand.asu_brand_local_search_url');
+    $local_search_url = $search_config->get('asu_brand.asu_brand_local_search_url');
+    $props['site'] = strlen($local_search_url) ? $local_search_url : \Drupal::request()->getHost();
 
     $block_output = [];
     // Markup containers where components will initialize.


### PR DESCRIPTION
I discovered that the recent update to add parameters for the Search URL and Local Search URL for the ASU Brand Header failed to provide a fallback to the site's domain when there was no local search URL provided.

This PR fixes that and fixes the format provided in the help text for the Local Search URL field. It shouldn't have said the `https://` protocol was required.

