### PR TITLE
WS2-1335: Fix typo in the name space for webspark-module-asu_brand

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "asuwebpplatforms/webspark-module-asu_brand",
+    "name": "asuwebplatforms/webspark-module-asu_brand",
     "description": "ASU Header component and brand assets.",
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",


### PR DESCRIPTION
Turns out that the typo was in this module's composer.json file.