### PR TITLE
Ws2 1563

### DIFF
--- a/asu_brand.services.yml
+++ b/asu_brand.services.yml
@@ -1,0 +1,3 @@
+services:
+  asu_brand.helper_functions:
+    class: Drupal\asu_brand\AsuBrandHelperFunctions

--- a/src/AsuBrandHelperFunctions.php
+++ b/src/AsuBrandHelperFunctions.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\asu_brand;
+
+use Drupal\Core\Html;
+
+/**
+ * Class AsuBrandHelperFunctions.php.
+ */
+class AsuBrandHelperFunctions {
+  /**
+   * @return array - Search URL for ASU.edu searches routed to Google, local host name (TLD) for Elastic search results
+   */
+  public function getSearchHosts() {
+    $search_config = \Drupal::config('asu_brand.settings');
+    $asu_search_url = $search_config->get('asu_brand.asu_brand_search_url') ?? '';
+    // Domain-specific results host
+    $local_search_url = $search_config->get('asu_brand.asu_brand_local_search_url') ?? \Drupal::request()->getHost();
+    // "opt-out"
+    $url_host = ($local_search_url === 'opt-out') ? '' : $local_search_url;
+    return ['asu_search_url' => $asu_search_url, 'url_host' => $url_host];
+  }
+
+  /**
+   * PHP version of encodeURIComponent from Javascript
+   * @param $str - Raw string
+   * @return string - Encoded string
+   */
+  public function encodeURIComponent($str): string {
+    $revert = array('%21'=>'!', '%2A'=>'*', '%28'=>'(', '%29'=>')');
+    return strtr(rawurlencode($str), $revert);
+  }
+}

--- a/src/Plugin/Block/AsuBrandHeaderBlock.php
+++ b/src/Plugin/Block/AsuBrandHeaderBlock.php
@@ -113,13 +113,10 @@ class AsuBrandHeaderBlock extends BlockBase {
       'brandLink' => 'https://www.asu.edu',
     ];
     // Search settings.
-    $search_config = \Drupal::config('asu_brand.settings');
-    $props['searchUrl'] = $search_config->get('asu_brand.asu_brand_search_url');
-    $local_search_url = $search_config->get('asu_brand.asu_brand_local_search_url');
-    $props['site'] = $local_search_url ?? \Drupal::request()->getHost();
-    // "opt-out" for use by ASU CMS, Integrated Search or with special
-    // dispensation.
-    if ($props['site'] == "opt-out") {
+    (array)$urls = \Drupal::service('asu_brand.helper_functions')->getSearchHosts();
+    $props['searchUrl'] = $urls['asu_search_url'];
+    $props['site'] = $urls['url_host'];
+    if ($props['site'] === '') { // "opt-out" was selected
       unset($props['site']);
     }
 


### PR DESCRIPTION
This adds two service methods for the webspark blocks fix (WS2-1563):
* getSearchHosts - Get the host names for the ASU search URL and the accompanying local hostname for local search results.
* encodeURIComponent - Mostly mimics Javascript's encodeURIComponent() to encode the keyword search strings before sending to the ASU search URL.

This must be merged at the same time as https://github.com/ASUWebPlatforms/webspark-module-webspark_blocks/pull/151.