### PR TITLE
WS2-1601 - Updated ASU Header block configuration form

### DIFF
--- a/asu_brand.libraries.yml
+++ b/asu_brand.libraries.yml
@@ -13,3 +13,7 @@ components-library:
   css:
     component:
       css/asu_brand.header.css: {}
+block__system_main_block:
+  css:
+    theme:
+      css/asu-brand-edit-form.css: {}

--- a/asu_brand.module
+++ b/asu_brand.module
@@ -96,7 +96,6 @@ function asu_brand_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form
   if ($form_id === 'block_form' && $form['settings']['provider']['#value'] === "asu_brand") {
     $form['settings']['label']['#title'] = t("Block admin title");
     $form['settings']['label']['#disabled'] = TRUE;
-    $form['settings']['label']['#access'] = FALSE;
     $form['settings']['label']['#value'] = 'ASU brand header';
     $form['settings']['label_display']['#title'] = t("Display block admin title");
     $form['settings']['label_display']['#value'] = FALSE;
@@ -106,6 +105,7 @@ function asu_brand_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form
     $form['settings']['admin_label']['#title'] = 'ASU Brand header';
     $form['region']['#weight'] = 10;
     $form['id']['#weight'] = 11;
+    $form['#attached']['library'][] = 'asu_brand/block__system_main_block';
   }
 
   // Menu link edit forms for content links.

--- a/asu_brand.module
+++ b/asu_brand.module
@@ -92,13 +92,20 @@ function asu_brand_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form
     }
   }
 
-  // Header block form tweaks.
+  // Header block form UX improvements
   if ($form_id === 'block_form' && $form['settings']['provider']['#value'] === "asu_brand") {
-    // Minor UX improvements
     $form['settings']['label']['#title'] = t("Block admin title");
+    $form['settings']['label']['#disabled'] = TRUE;
+    $form['settings']['label']['#access'] = FALSE;
+    $form['settings']['label']['#value'] = 'ASU brand header';
     $form['settings']['label_display']['#title'] = t("Display block admin title");
-    $form['settings']['label_display']['#default_value'] = FALSE;
-    $form['settings']['label_display']['#description'] = t("For the ASU header, you do not want to display the block admin title to visitors.");
+    $form['settings']['label_display']['#value'] = FALSE;
+    $form['settings']['label_display']['#disabled'] = TRUE;
+    $form['settings']['label_display']['#access'] = FALSE;
+    $form['settings']['label_display']['#description'] = t("Do not display the block admin title to visitors.");
+    $form['settings']['admin_label']['#title'] = 'ASU Brand header';
+    $form['region']['#weight'] = 10;
+    $form['id']['#weight'] = 11;
   }
 
   // Menu link edit forms for content links.

--- a/css/asu-brand-edit-form.css
+++ b/css/asu-brand-edit-form.css
@@ -1,0 +1,3 @@
+.block-system-main-block > form#block-form > .form-item.form-item-settings-label {
+  display: none;
+}

--- a/src/Form/AsuBrandSettingsForm.php
+++ b/src/Form/AsuBrandSettingsForm.php
@@ -110,7 +110,7 @@ class AsuBrandSettingsForm extends ConfigFormBase {
       '#description' => $this->t('If empty, your current site\'s base URL will be used. Optionally, you can override
          with the URL of your choice to be used for scoping local search. Use the format: yourdomain.asu.edu'),
     ];
-
+    $form['#attached']['library'][] = 'asu_brand/';
     return parent::buildForm($form, $form_state);
   }
 

--- a/src/Plugin/Block/AsuBrandHeaderBlock.php
+++ b/src/Plugin/Block/AsuBrandHeaderBlock.php
@@ -1,4 +1,6 @@
-<?php
+<?php /** @noinspection SqlDialectInspection */
+
+/** @noinspection SqlNoDataSourceInspection */
 
 namespace Drupal\asu_brand\Plugin\Block;
 
@@ -34,7 +36,7 @@ class AsuBrandHeaderBlock extends BlockBase {
 
     // Rally props to pass to JS as drupalSettings.
     $props = [];
-    $props['baseUrl'] = $this->getBaseUrl();
+    $props['baseUrl'] = $config['asu_brand_header_block_base_url'] ?? $this->getBaseUrl();
     $props['title'] = $config['asu_brand_header_block_title'];
     $props['parentOrg'] = $config['asu_brand_header_block_parent_org'];
     $props['parentOrgUrl'] = $config['asu_brand_header_block_parent_org_url'];
@@ -181,90 +183,64 @@ class AsuBrandHeaderBlock extends BlockBase {
     // Config for this instance.
     $config = $this->getConfiguration();
 
-    $form['asu_brand_header_block_title'] = [
+    // Titles (Main, Parent)
+    $form['titles'] = array(
+      '#type' => 'details',
+      '#title' => $this->t('Site titles'),
+      '#open' => TRUE,
+      '#collapsible' => FALSE
+    );
+    $form['titles']['asu_brand_header_block_title'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Site name'),
-      '#description' => $this->t('Site title to appear in the header.'),
+      '#title' => $this->t('Site title'),
+      '#description' => $this->t('Main site title in white ASU header.'),
       '#default_value' => $config['asu_brand_header_block_title'] ?? \Drupal::config('system.site')->get('name'),
       '#required' => TRUE
     ];
-    $form['asu_brand_header_block_base_url'] = [
+    $form['titles']['asu_brand_header_block_base_url'] = [
       '#type' => 'url',
       '#title' => $this->t('Site URL'),
-      '#description' => $this->t('URL of the site.'),
-      '#default_value' => $this->getBaseUrl(),
+      '#description' => $this->t("URL of this site's home page."),
+      '#default_value' => $config['asu_brand_header_block_base_url'] ?? $this->getBaseUrl(),
       '#required' => TRUE
     ];
-
-    $form['partner'] = [
-      '#type' => 'details',
-      '#title' => $this->t('Partner'),
-      '#collapsible' => TRUE,
-      '#collapsed' => TRUE,
-      '#description' => $this->t('Important: Use of the Partner Header must first be approved by the ASU Marketing Hub. Do not enable if you have not first received approval.'),
-    ];
-
-    $form['partner']['asu_brand_header_block_partner_enabled'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Is Partner?'),
-      '#default_value' => !empty($config['asu_brand_header_block_partner_enabled']) ?
-        $config['asu_brand_header_block_partner_enabled'] : 0,
-    ];
-
-    $form['partner']['asu_brand_header_block_partner_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Partner URL'),
-      '#description' => $this->t('URL of the partner unit.'),
-      '#default_value' => !empty($config['asu_brand_header_block_partner_url']) ?
-        $config['asu_brand_header_block_partner_url'] : '',
-      '#required' => FALSE
-    ];
-    $form['partner']['asu_brand_header_block_partner_logo_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Partner Logo URL'),
-      '#description' => $this->t('URL of the partner logo image.'),
-      '#default_value' => !empty($config['asu_brand_header_block_partner_logo_url']) ?
-        $config['asu_brand_header_block_partner_logo_url'] : '',
-      '#required' => FALSE
-    ];
-    $form['partner']['asu_brand_header_block_partner_logo_alt'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Partner Logo Alt'),
-      '#description' => $this->t('The ALT attribute of the partner logo image.'),
-      '#default_value' => !empty($config['asu_brand_header_block_partner_logo_alt']) ?
-        $config['asu_brand_header_block_partner_logo_alt'] : '',
-      '#required' => FALSE
-    ];
-    $form['asu_brand_header_block_parent_org'] = [
+    $form['titles']['asu_brand_header_block_parent_org'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Parent unit name'),
-      '#description' => $this->t('Optional. Name of the parent unit.'),
+      '#description' => $this->t("(optional) Name of the ASU parent unit. Will appear above the site title. Leave blank if none."),
       '#default_value' => $config['asu_brand_header_block_parent_org'] ?? '',
-      '#required' => FALSE
+      '#states' => array(
+        'required' => array(
+          ':input[name="settings[titles][asu_brand_header_block_parent_org_url]"]' => array(
+            'filled' => TRUE,
+          ),
+        ),
+      ),
     ];
-    $form['asu_brand_header_block_parent_org_url'] = [
+    $form['titles']['asu_brand_header_block_parent_org_url'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Parent Department URL'),
-      '#description' => $this->t('Optional. Absolute or relative URL of the parent unit.'),
+      '#title' => $this->t('Parent department URL'),
+      '#description' => $this->t('Absolute or relative URL of the parent unit. Leave blank if none.'),
       '#default_value' => $config['asu_brand_header_block_parent_org_url'] ?? '',
-      '#required' => FALSE
     ];
-    $form['asu_brand_header_block_sync_session'] = [
+
+
+    $form['menus'] = array(
+      '#type' => 'details',
+      '#title' => $this->t('Menu settings'),
+      '#open' => TRUE,
+      '#collapsible' => FALSE
+    );
+    // Menu settings
+    $form['menus']['asu_brand_header_block_menu_enabled'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Sync login status with Drupal session'),
-      '#description' => $this->t('Recommended. Keeps the header\'s login/out
-        status synced with the users\'s Drupal session. If disabled, the header
-        will reflect the user\'s single-sign on status and they may become
-        confused about whether they are logged in or not.'),
-      '#default_value' => $config['asu_brand_header_block_sync_session'] ?? 1,
-    ];
-    $form['asu_brand_header_block_menu_enabled'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Insert menu into header'),
-      '#description' => $this->t('Insert a site menu into the ASU header and display it responsively. Important note: the first enabled menu link will always be treated as the home menu link and will be converted into a home icon. To change which menu link is used as home, reorder your menu links.'),
+      '#title' => $this->t('Insert menu into ASU header'),
+      '#description' => $this->t('Insert a site menu into the ASU header and display it responsively. Important note: the first enabled' .
+        ' menu link will always be treated as the home menu link and will be converted into a home icon. To change which menu link' .
+        ' is used as home, reorder your menu links.'),
       '#default_value' => $config['asu_brand_header_block_menu_enabled'] ?? 1,
     ];
-    $form['asu_brand_header_block_menu_name'] = [
+    $form['menus']['asu_brand_header_block_menu_name'] = [
       '#type' => 'select',
       '#title' => $this->t('Menu to insert'),
       '#description' => $this->t('Select the menu to insert.'),
@@ -279,7 +255,7 @@ class AsuBrandHeaderBlock extends BlockBase {
         ),
       ),
     ];
-    $form['asu_brand_header_block_expand_on_hover'] = [
+    $form['menus']['asu_brand_header_block_expand_on_hover'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Expand on hover'),
       '#description' => $this->t('If enabled, menu dropdowns will expand on hover. Allows for top-level menu items with children to be clickable as navigation destinations.'),
@@ -293,75 +269,167 @@ class AsuBrandHeaderBlock extends BlockBase {
         ),
       ),
     ];
-    $form['asu_brand_header_block_login_path'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Login path'),
-      '#description' => $this->t('Login path for the site.'),
-      '#default_value' => $config['asu_brand_header_block_login_path'] ?? '/caslogin',
-      '#required' => TRUE
+
+    // CTA buttons
+    $style_options = [
+      'gold' => 'Gold',
+      'maroon' => 'Maroon',
+      'light' => 'Gray 2',
+      'dark' => 'Gray 7',
     ];
-    $form['asu_brand_header_block_logout_path'] = [
+    $form['cta'] = array(
+      '#type' => 'details',
+      '#title' => $this->t('Call To Action buttons'),
+      '#description' => 'If desired, add one or two CTA buttons to the right hand side of the main site menu.',
+      '#open' => FALSE,
+      '#collapsible' => TRUE
+    );
+    // Button 1
+    $form['cta']['cta1'] = array(
+      '#type' => 'details',
+      '#title' => $this->t('Button 1'),
+      '#open' => TRUE,
+      '#collapsible' => FALSE
+    );
+    $form['cta']['cta1']['asu_brand_header_block_cta1_label'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Logout path'),
-      '#description' => $this->t('Logout path for the site.'),
-      '#default_value' => $config['asu_brand_header_block_logout_path'] ?? '/caslogout',
-      '#required' => TRUE
-    ];
-    $form['asu_brand_header_block_cta1_label'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Call to action button 1 label'),
+      '#title' => $this->t('Text'),
       '#default_value' => $config['asu_brand_header_block_cta1_label'] ?? '',
     ];
-    $form['asu_brand_header_block_cta1_url'] = [
+    $form['cta']['cta1']['asu_brand_header_block_cta1_url'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Call to action button 1 URL or path'),
+      '#title' => $this->t('URL target'),
       '#default_value' => $config['asu_brand_header_block_cta1_url'] ?? '',
       '#states' => array(
         // Require this field when the label is filled.
         'required' => array(
-          ':input[name="settings[asu_brand_header_block_cta1_label]"]' => array(
+          ':input[name="settings[cta][cta1][asu_brand_header_block_cta1_label]"]' => array(
             'filled' => TRUE,
           ),
         ),
       ),
     ];
-
-    $style_options = [
-        'gold' => 'Gold',
-        'maroon' => 'Maroon',
-        'light' => 'Gray 2',
-        'dark' => 'Gray 7',
-      ];
-    $form['asu_brand_header_block_cta1_style'] = [
+    $form['cta']['cta1']['asu_brand_header_block_cta1_style'] = [
       '#type' => 'select',
-      '#title' => $this->t('Call to action button 1 style'),
+      '#title' => $this->t('Style'),
       '#default_value' => $config['asu_brand_header_block_cta1_style'] ?? '',
       '#options' => $style_options,
     ];
-    $form['asu_brand_header_block_cta2_label'] = [
+    // Button 2
+    $form['cta']['cta2'] = array(
+      '#type' => 'details',
+      '#title' => $this->t('Button 2'),
+      '#open' => TRUE,
+      '#collapsible' => FALSE
+    );
+    $form['cta']['cta2']['asu_brand_header_block_cta2_label'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Call to action button 2 label'),
+      '#title' => $this->t('Text'),
       '#default_value' => $config['asu_brand_header_block_cta2_label'] ?? '',
     ];
-    $form['asu_brand_header_block_cta2_url'] = [
+    $form['cta']['cta2']['asu_brand_header_block_cta2_url'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Call to action button 2 URL or path'),
+      '#title' => $this->t('URL target'),
       '#default_value' => $config['asu_brand_header_block_cta2_url'] ?? '',
       '#states' => array(
         // Require this field when the label is filled.
         'required' => array(
-          ':input[name="settings[asu_brand_header_block_cta2_label]"]' => array(
+          ':input[name="settings[cta][cta2][asu_brand_header_block_cta2_label]"]' => array(
             'filled' => TRUE,
           ),
         ),
       ),
     ];
-
-    $form['asu_brand_header_block_cta2_style'] = [
+    $form['cta']['cta2']['asu_brand_header_block_cta2_style'] = [
       '#type' => 'select',
-      '#title' => $this->t('Call to action button 2 style'),
+      '#title' => $this->t('Style'),
       '#default_value' => $config['asu_brand_header_block_cta2_style'] ?? '',
       '#options' => $style_options,
+    ];
+
+    // Partner header
+    $form['partner'] = [
+      '#type' => 'details',
+      '#title' => $this->t('ASU Partner Header'),
+      '#collapsible' => TRUE,
+      '#collapsed' => TRUE,
+      '#description' => $this->t('<strong>Important</strong>: Use of the Partner Header must first be approved by the ASU Marketing Hub. Do not enable if you have not first received approval. Otherwise, leave this section blank.'),
+    ];
+    $form['partner']['asu_brand_header_block_partner_enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Is Partner?'),
+      '#default_value' => !empty($config['asu_brand_header_block_partner_enabled']) ?
+        $config['asu_brand_header_block_partner_enabled'] : 0,
+    ];
+    $form['partner']['asu_brand_header_block_partner_url'] = [
+      '#type' => 'url',
+      '#title' => $this->t('Partner URL'),
+      '#description' => $this->t('URL of the partner unit. Absolute URLs only.'),
+      '#default_value' => !empty($config['asu_brand_header_block_partner_url']) ?
+        $config['asu_brand_header_block_partner_url'] : '',
+      '#states' => [
+        'required' => [
+          ':input[name="settings[partner][asu_brand_header_block_partner_enabled]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+    $form['partner']['asu_brand_header_block_partner_logo_url'] = [
+      '#type' => 'url',
+      '#title' => $this->t('Partner Logo URL'),
+      '#description' => $this->t('URL of the partner logo image. Absolute URLs only.'),
+      '#default_value' => !empty($config['asu_brand_header_block_partner_logo_url']) ?
+        $config['asu_brand_header_block_partner_logo_url'] : '',
+      '#states' => [
+        'required' => [
+          ':input[name="settings[partner][asu_brand_header_block_partner_enabled]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+    $form['partner']['asu_brand_header_block_partner_logo_alt'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Partner Logo Alt'),
+      '#description' => $this->t('The ALT attribute of the partner logo image.'),
+      '#default_value' => !empty($config['asu_brand_header_block_partner_logo_alt']) ?
+        $config['asu_brand_header_block_partner_logo_alt'] : '',
+      '#states' => [
+        'required' => [
+          ':input[name="settings[partner][asu_brand_header_block_partner_enabled]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+
+    // Login URLs
+    $form['logins'] = array(
+      '#type' => 'details',
+      '#collapsible' => TRUE,
+      '#collapsed' => TRUE,
+      '#description' => $this->t('Menu routing paths that trigger logons/logoffs (usually CAS-related in Webspark). ' .
+      'Do not change these settings unless you know what you are doing.'),
+      '#title' => $this->t('Login Paths')
+    );
+    $form['logins']['asu_brand_header_block_login_path'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Login path'),
+      '#default_value' => $config['asu_brand_header_block_login_path'] ?? '/caslogin',
+      '#description' => $this->t('Use /caslogin as the recommended CAS default'),
+      '#required' => TRUE
+    ];
+    $form['logins']['asu_brand_header_block_logout_path'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Logout path'),
+      '#default_value' => $config['asu_brand_header_block_logout_path'] ?? '/caslogout',
+      '#description' => $this->t("Use /caslogout as the recommended CAS default"),
+      '#required' => TRUE
+    ];
+    $form['logins']['asu_brand_header_block_sync_session'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Sync login status with Drupal session'),
+      '#description' => $this->t('Recommended. Keeps the header\'s login/out
+        status synced with the users\'s Drupal session. If disabled, the header
+        will reflect the user\'s single-sign on status and they may become
+        confused about whether they are logged in or not.'),
+      '#default_value' => $config['asu_brand_header_block_sync_session'] ?? 1,
     ];
 
     return $form;
@@ -388,13 +456,37 @@ class AsuBrandHeaderBlock extends BlockBase {
    */
   public function blockSubmit($form, FormStateInterface $form_state) {
     parent::blockSubmit($form, $form_state);
-
     $values = $form_state->getValues();
 
     $this->configuration['asu_brand_header_block_title'] =
-      $values['asu_brand_header_block_title'];
+      $values['titles']['asu_brand_header_block_title'];
     $this->configuration['asu_brand_header_block_base_url'] =
-      $values['asu_brand_header_block_base_url'];
+      $values['titles']['asu_brand_header_block_base_url'];
+    $this->configuration['asu_brand_header_block_parent_org'] =
+      $values['titles']['asu_brand_header_block_parent_org'];
+    $this->configuration['asu_brand_header_block_parent_org_url'] =
+      $values['titles']['asu_brand_header_block_parent_org_url'];
+
+    $this->configuration['asu_brand_header_block_cta1_label'] =
+      $values['cta']['cta1']['asu_brand_header_block_cta1_label'];
+    $this->configuration['asu_brand_header_block_cta1_url'] =
+      $values['cta']['cta1']['asu_brand_header_block_cta1_url'];
+    $this->configuration['asu_brand_header_block_cta1_style'] =
+      $values['cta']['cta1']['asu_brand_header_block_cta1_style'];
+    $this->configuration['asu_brand_header_block_cta2_label'] =
+      $values['cta']['cta2']['asu_brand_header_block_cta2_label'];
+    $this->configuration['asu_brand_header_block_cta2_url'] =
+      $values['cta']['cta2']['asu_brand_header_block_cta2_url'];
+    $this->configuration['asu_brand_header_block_cta2_style'] =
+      $values['cta']['cta2']['asu_brand_header_block_cta2_style'];
+
+    $this->configuration['asu_brand_header_block_menu_enabled'] =
+      $values['menus']['asu_brand_header_block_menu_enabled'];
+    $this->configuration['asu_brand_header_block_menu_name'] =
+      $values['menus']['asu_brand_header_block_menu_name'];
+    $this->configuration['asu_brand_header_block_expand_on_hover'] =
+      $values['menus']['asu_brand_header_block_expand_on_hover'];
+
     $this->configuration['asu_brand_header_block_partner_enabled'] =
       $values['partner']['asu_brand_header_block_partner_enabled'];
     $this->configuration['asu_brand_header_block_partner_url'] =
@@ -403,34 +495,14 @@ class AsuBrandHeaderBlock extends BlockBase {
       $values['partner']['asu_brand_header_block_partner_logo_url'];
     $this->configuration['asu_brand_header_block_partner_logo_alt'] =
       $values['partner']['asu_brand_header_block_partner_logo_alt'];
-    $this->configuration['asu_brand_header_block_parent_org'] =
-      $values['asu_brand_header_block_parent_org'];
-    $this->configuration['asu_brand_header_block_parent_org_url'] =
-      $values['asu_brand_header_block_parent_org_url'];
-    $this->configuration['asu_brand_header_block_sync_session'] =
-      $values['asu_brand_header_block_sync_session'];
-    $this->configuration['asu_brand_header_block_menu_enabled'] =
-      $values['asu_brand_header_block_menu_enabled'];
-    $this->configuration['asu_brand_header_block_menu_name'] =
-      $values['asu_brand_header_block_menu_name'];
-    $this->configuration['asu_brand_header_block_expand_on_hover'] =
-      $values['asu_brand_header_block_expand_on_hover'];
+
     $this->configuration['asu_brand_header_block_login_path'] =
-      $values['asu_brand_header_block_login_path'];
+      $values['logins']['asu_brand_header_block_login_path'];
     $this->configuration['asu_brand_header_block_logout_path'] =
-      $values['asu_brand_header_block_logout_path'];
-    $this->configuration['asu_brand_header_block_cta1_label'] =
-      $values['asu_brand_header_block_cta1_label'];
-    $this->configuration['asu_brand_header_block_cta1_url'] =
-      $values['asu_brand_header_block_cta1_url'];
-    $this->configuration['asu_brand_header_block_cta1_style'] =
-      $values['asu_brand_header_block_cta1_style'];
-    $this->configuration['asu_brand_header_block_cta2_label'] =
-      $values['asu_brand_header_block_cta2_label'];
-    $this->configuration['asu_brand_header_block_cta2_url'] =
-      $values['asu_brand_header_block_cta2_url'];
-    $this->configuration['asu_brand_header_block_cta2_style'] =
-      $values['asu_brand_header_block_cta2_style'];
+      $values['logins']['asu_brand_header_block_logout_path'];
+    $this->configuration['asu_brand_header_block_sync_session'] =
+      $values['logins']['asu_brand_header_block_sync_session'];
+
   }
 
   /**


### PR DESCRIPTION
* Reorganized the form - combining fields into fieldsets, reordered fields, etc.
* Added some "required" validation to some form elements.
* Removed/locked down superfluous fields end users won't be editing.
* Updated descriptive text.

**Technical notes**

The length of the patches' diffs is mostly due to the reordering of the code to match the form's changed layout.

The form's machine name structure has changed, but that shouldn't affect the storage of existing values on any sites because:
1. No fields have been added/removed, 
2. The mapping between the form_state $values array and the configuration object has been updated, and
3. The existing configuration object remained the same.

The @noinspection commented are IDE-related.